### PR TITLE
Add Render free-tier deploy config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,4 +31,6 @@ USER appuser
 WORKDIR /app/backend
 EXPOSE 8000
 
-CMD ["uv", "run", "uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]
+# Bind to $PORT when the host injects one (Render, Cloud Run, …); fall back to
+# 8000 so local `docker compose up` keeps working.
+CMD exec uv run uvicorn app.main:app --host 0.0.0.0 --port ${PORT:-8000}

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,14 @@
+# Render Blueprint — https://render.com/docs/blueprint-spec
+# Single Docker web service: the multi-stage build bakes the SPA into the
+# FastAPI image, so one container serves both the API and the UI.
+services:
+  - type: web
+    name: everyday-developer-tools
+    runtime: docker
+    dockerfilePath: ./Dockerfile
+    dockerContext: .
+    plan: free
+    region: oregon
+    branch: develop
+    autoDeploy: true
+    healthCheckPath: /api/health


### PR DESCRIPTION
## What

Wires the repo up for one-click free deploys on [Render](https://render.com).

- **`render.yaml`** — Render Blueprint defining a single Docker web service on the **free** plan. The existing multi-stage `Dockerfile` already bakes the SPA into the FastAPI image, so one container serves both the API and the UI. Auto-deploys on push to `develop`; health-checked at `/api/health`.
- **`Dockerfile`** — `CMD` now binds to `$PORT` (Render injects this) with an `8000` fallback so local `docker compose up` is unchanged.

## Why

The hardcoded `--port 8000` would not receive traffic on Render, which routes to the container's `$PORT`. Redis is optional (`rate_limit.py` falls back to in-memory limiting), so no add-on is needed — one free container is enough.

## Verification

- `docker compose up --build` → app still serves on `localhost:8000` (fallback path).
- `${PORT:-8000}` expands correctly under `/bin/sh`; `exec` keeps uvicorn as the container's main process for clean SIGTERM handling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment configuration to support environment-based port configuration
  * Added new deployment configuration with automatic deployment and health monitoring capabilities

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vib795/everyday-developer-tools/pull/50?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->