### PR TITLE
Add dark/light theme (dark by default)

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3,10 +3,26 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="color-scheme" content="dark light" />
     <title>Developer Tools</title>
     <meta name="description" content="A suite of developer tools: JSON, regex, strings, encoding, time, and more." />
+    <script>
+      // Apply the saved theme before first paint to avoid a flash of the wrong
+      // colors. Dark is the default — only an explicit "light" choice opts out.
+      (function () {
+        try {
+          if (localStorage.getItem("theme") === "light") {
+            document.documentElement.classList.remove("dark");
+          } else {
+            document.documentElement.classList.add("dark");
+          }
+        } catch (e) {
+          document.documentElement.classList.add("dark");
+        }
+      })();
+    </script>
   </head>
-  <body class="bg-slate-50 text-slate-900 antialiased">
+  <body class="bg-slate-50 text-slate-900 antialiased dark:bg-slate-950 dark:text-slate-100">
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>

--- a/frontend/src/components/CodeBlock.tsx
+++ b/frontend/src/components/CodeBlock.tsx
@@ -21,7 +21,7 @@ export function CodeBlock({ value, showLineNumbers = false, copyable = true }: P
           <div className="flex">
             <div
               aria-hidden
-              className="select-none border-r border-slate-200 pr-3 text-right text-slate-400"
+              className="select-none border-r border-slate-200 pr-3 text-right text-slate-400 dark:border-slate-800 dark:text-slate-500"
             >
               {lines.map((_, i) => (
                 <div key={i}>{i + 1}</div>

--- a/frontend/src/components/ErrorBanner.tsx
+++ b/frontend/src/components/ErrorBanner.tsx
@@ -7,7 +7,7 @@ export function ErrorBanner({ message }: Props) {
   return (
     <div
       role="alert"
-      className="rounded-md border border-rose-200 bg-rose-50 px-4 py-3 text-sm text-rose-900"
+      className="rounded-md border border-rose-200 bg-rose-50 px-4 py-3 text-sm text-rose-900 dark:border-rose-900 dark:bg-rose-950/40 dark:text-rose-200"
     >
       {message}
     </div>

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -7,7 +7,7 @@ export function Layout({ children }: { children: ReactNode }) {
     <div className="flex min-h-screen flex-col">
       <Navbar />
       <main className="mx-auto w-full max-w-5xl flex-1 px-4 py-8">{children}</main>
-      <footer className="border-t border-slate-200 bg-white py-4 text-center text-xs text-slate-500">
+      <footer className="border-t border-slate-200 bg-white py-4 text-center text-xs text-slate-500 dark:border-slate-800 dark:bg-slate-900">
         Developer Tools · open-source under MIT
       </footer>
     </div>

--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -3,6 +3,7 @@ import { Link, NavLink, useLocation } from "react-router-dom";
 import clsx from "clsx";
 
 import { TOOL_GROUPS, ToolLink } from "../tools";
+import { ThemeToggle } from "./ThemeToggle";
 
 interface DropdownProps {
   label: string;
@@ -28,25 +29,25 @@ function Dropdown({ label, items }: DropdownProps) {
       <button
         type="button"
         onClick={() => setOpen((v) => !v)}
-        className="rounded px-3 py-2 text-sm font-medium text-slate-700 hover:bg-slate-100"
+        className="rounded px-3 py-2 text-sm font-medium text-slate-700 hover:bg-slate-100 dark:text-slate-300 dark:hover:bg-slate-800"
         aria-expanded={open}
       >
         {label}
-        <span aria-hidden className="ml-1 text-slate-400">
+        <span aria-hidden className="ml-1 text-slate-400 dark:text-slate-500">
           ▾
         </span>
       </button>
       {open && (
         <div
           role="menu"
-          className="absolute left-0 z-20 mt-1 w-64 rounded-md border border-slate-200 bg-white py-1 shadow-lg"
+          className="absolute left-0 z-20 mt-1 w-64 rounded-md border border-slate-200 bg-white py-1 shadow-lg dark:border-slate-800 dark:bg-slate-900"
         >
           {items.map((it) => (
             <Link
               key={it.path}
               to={it.path}
               role="menuitem"
-              className="block px-3 py-2 text-sm text-slate-700 hover:bg-slate-50"
+              className="block px-3 py-2 text-sm text-slate-700 hover:bg-slate-50 dark:text-slate-300 dark:hover:bg-slate-800"
             >
               {it.label}
             </Link>
@@ -61,11 +62,13 @@ export function Navbar() {
   const [mobile, setMobile] = useState(false);
 
   return (
-    <header className="sticky top-0 z-30 border-b border-slate-200 bg-white/90 backdrop-blur">
+    <header className="sticky top-0 z-30 border-b border-slate-200 bg-white/90 backdrop-blur dark:border-slate-800 dark:bg-slate-900/90">
       <div className="mx-auto flex max-w-7xl items-center justify-between px-4 py-2">
         <Link to="/" className="flex items-center gap-2">
           <span className="rounded bg-brand px-2 py-1 text-sm font-semibold text-white">DT</span>
-          <span className="text-sm font-semibold text-slate-900">Developer Tools</span>
+          <span className="text-sm font-semibold text-slate-900 dark:text-slate-100">
+            Developer Tools
+          </span>
         </Link>
 
         <nav className="hidden items-center gap-1 md:flex">
@@ -75,7 +78,9 @@ export function Navbar() {
             className={({ isActive }) =>
               clsx(
                 "rounded px-3 py-2 text-sm font-medium",
-                isActive ? "bg-slate-100 text-slate-900" : "text-slate-700 hover:bg-slate-100",
+                isActive
+                  ? "bg-slate-100 text-slate-900 dark:bg-slate-800 dark:text-slate-100"
+                  : "text-slate-700 hover:bg-slate-100 dark:text-slate-300 dark:hover:bg-slate-800",
               )
             }
           >
@@ -91,7 +96,9 @@ export function Navbar() {
                 className={({ isActive }) =>
                   clsx(
                     "rounded px-3 py-2 text-sm font-medium",
-                    isActive ? "bg-slate-100 text-slate-900" : "text-slate-700 hover:bg-slate-100",
+                    isActive
+                      ? "bg-slate-100 text-slate-900 dark:bg-slate-800 dark:text-slate-100"
+                      : "text-slate-700 hover:bg-slate-100 dark:text-slate-300 dark:hover:bg-slate-800",
                   )
                 }
               >
@@ -101,33 +108,38 @@ export function Navbar() {
           )}
         </nav>
 
-        <button
-          type="button"
-          className="md:hidden btn-ghost"
-          onClick={() => setMobile((v) => !v)}
-          aria-expanded={mobile}
-          aria-label="Toggle menu"
-        >
-          ☰
-        </button>
+        <div className="flex items-center gap-1">
+          <ThemeToggle />
+          <button
+            type="button"
+            className="md:hidden btn-ghost"
+            onClick={() => setMobile((v) => !v)}
+            aria-expanded={mobile}
+            aria-label="Toggle menu"
+          >
+            ☰
+          </button>
+        </div>
       </div>
 
       {mobile && (
-        <div className="border-t border-slate-200 bg-white md:hidden">
+        <div className="border-t border-slate-200 bg-white md:hidden dark:border-slate-800 dark:bg-slate-900">
           <nav className="space-y-3 px-4 py-3">
             <Link to="/" onClick={() => setMobile(false)} className="block text-sm font-medium">
               Home
             </Link>
             {TOOL_GROUPS.map((g) => (
               <div key={g.label}>
-                <p className="text-xs uppercase tracking-wide text-slate-500">{g.label}</p>
+                <p className="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">
+                  {g.label}
+                </p>
                 <ul className="mt-1 space-y-1">
                   {g.items.map((it) => (
                     <li key={it.path}>
                       <Link
                         to={it.path}
                         onClick={() => setMobile(false)}
-                        className="block rounded px-2 py-1 text-sm text-slate-700 hover:bg-slate-50"
+                        className="block rounded px-2 py-1 text-sm text-slate-700 hover:bg-slate-50 dark:text-slate-300 dark:hover:bg-slate-800"
                       >
                         {it.label}
                       </Link>

--- a/frontend/src/components/PageHeader.tsx
+++ b/frontend/src/components/PageHeader.tsx
@@ -6,8 +6,12 @@ interface Props {
 export function PageHeader({ title, description }: Props) {
   return (
     <header className="mb-6">
-      <h1 className="text-2xl font-semibold tracking-tight text-slate-900">{title}</h1>
-      {description && <p className="mt-1 text-sm text-slate-600">{description}</p>}
+      <h1 className="text-2xl font-semibold tracking-tight text-slate-900 dark:text-slate-100">
+        {title}
+      </h1>
+      {description && (
+        <p className="mt-1 text-sm text-slate-600 dark:text-slate-400">{description}</p>
+      )}
     </header>
   );
 }

--- a/frontend/src/components/ThemeToggle.tsx
+++ b/frontend/src/components/ThemeToggle.tsx
@@ -1,0 +1,63 @@
+import { useEffect, useState } from "react";
+
+type Theme = "dark" | "light";
+
+function currentTheme(): Theme {
+  return document.documentElement.classList.contains("dark") ? "dark" : "light";
+}
+
+export function ThemeToggle() {
+  // The inline script in index.html sets the initial class before paint;
+  // we read it back here so the toggle starts in sync.
+  const [theme, setTheme] = useState<Theme>(currentTheme);
+
+  useEffect(() => {
+    document.documentElement.classList.toggle("dark", theme === "dark");
+    localStorage.setItem("theme", theme);
+  }, [theme]);
+
+  const next: Theme = theme === "dark" ? "light" : "dark";
+
+  return (
+    <button
+      type="button"
+      onClick={() => setTheme(next)}
+      className="rounded p-2 text-slate-600 hover:bg-slate-100 dark:text-slate-300 dark:hover:bg-slate-800"
+      aria-label={`Switch to ${next} mode`}
+      title={`Switch to ${next} mode`}
+    >
+      {theme === "dark" ? (
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="18"
+          height="18"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          aria-hidden
+        >
+          <circle cx="12" cy="12" r="4" />
+          <path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M6.34 17.66l-1.41 1.41M19.07 4.93l-1.41 1.41" />
+        </svg>
+      ) : (
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="18"
+          height="18"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          aria-hidden
+        >
+          <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
+        </svg>
+      )}
+    </button>
+  );
+}

--- a/frontend/src/pages/calc/Chmod.tsx
+++ b/frontend/src/pages/calc/Chmod.tsx
@@ -37,16 +37,16 @@ export function Chmod() {
       </form>
       <ErrorBanner message={error} />
       {data && data.error && (
-        <div role="alert" className="rounded-md border border-rose-200 bg-rose-50 px-4 py-3 text-sm text-rose-900">
+        <div role="alert" className="rounded-md border border-rose-200 dark:border-rose-900 bg-rose-50 dark:bg-rose-950/40 px-4 py-3 text-sm text-rose-900 dark:text-rose-200">
           {data.error}
         </div>
       )}
       {data && !data.error && (
         <section className="card text-sm">
           <dl className="grid grid-cols-[100px_1fr] gap-y-2">
-            <dt className="text-slate-500">Numeric</dt>
+            <dt className="text-slate-500 dark:text-slate-400">Numeric</dt>
             <dd className="font-mono">{data.numeric}</dd>
-            <dt className="text-slate-500">Symbolic</dt>
+            <dt className="text-slate-500 dark:text-slate-400">Symbolic</dt>
             <dd className="font-mono">{data.symbolic}</dd>
           </dl>
         </section>

--- a/frontend/src/pages/calc/Cidr.tsx
+++ b/frontend/src/pages/calc/Cidr.tsx
@@ -37,36 +37,36 @@ export function Cidr() {
       </form>
       <ErrorBanner message={error} />
       {data && data.error && (
-        <div role="alert" className="rounded-md border border-rose-200 bg-rose-50 px-4 py-3 text-sm text-rose-900">
+        <div role="alert" className="rounded-md border border-rose-200 dark:border-rose-900 bg-rose-50 dark:bg-rose-950/40 px-4 py-3 text-sm text-rose-900 dark:text-rose-200">
           {data.error}
         </div>
       )}
       {data && !data.error && (
         <section className="card text-sm">
           <dl className="grid grid-cols-[140px_1fr] gap-y-2">
-            <dt className="text-slate-500">IP version</dt><dd>{data.version}</dd>
-            <dt className="text-slate-500">Prefix length</dt><dd>/{data.prefix}</dd>
-            <dt className="text-slate-500">Network</dt><dd className="font-mono">{data.network}</dd>
-            <dt className="text-slate-500">Netmask</dt><dd className="font-mono">{data.netmask}</dd>
+            <dt className="text-slate-500 dark:text-slate-400">IP version</dt><dd>{data.version}</dd>
+            <dt className="text-slate-500 dark:text-slate-400">Prefix length</dt><dd>/{data.prefix}</dd>
+            <dt className="text-slate-500 dark:text-slate-400">Network</dt><dd className="font-mono">{data.network}</dd>
+            <dt className="text-slate-500 dark:text-slate-400">Netmask</dt><dd className="font-mono">{data.netmask}</dd>
             {data.broadcast && (
               <>
-                <dt className="text-slate-500">Broadcast</dt>
+                <dt className="text-slate-500 dark:text-slate-400">Broadcast</dt>
                 <dd className="font-mono">{data.broadcast}</dd>
               </>
             )}
             {data.first_host && (
               <>
-                <dt className="text-slate-500">First host</dt>
+                <dt className="text-slate-500 dark:text-slate-400">First host</dt>
                 <dd className="font-mono">{data.first_host}</dd>
               </>
             )}
             {data.last_host && (
               <>
-                <dt className="text-slate-500">Last host</dt>
+                <dt className="text-slate-500 dark:text-slate-400">Last host</dt>
                 <dd className="font-mono">{data.last_host}</dd>
               </>
             )}
-            <dt className="text-slate-500"># hosts</dt>
+            <dt className="text-slate-500 dark:text-slate-400"># hosts</dt>
             <dd className="font-mono">{data.num_hosts.toLocaleString()}</dd>
           </dl>
         </section>

--- a/frontend/src/pages/calc/Color.tsx
+++ b/frontend/src/pages/calc/Color.tsx
@@ -32,7 +32,7 @@ export function Color() {
       <PageHeader title="Color" description="Convert color formats and check WCAG contrast." />
 
       <form onSubmit={onConvert} className="card space-y-4">
-        <h2 className="text-base font-semibold text-slate-700">Convert</h2>
+        <h2 className="text-base font-semibold text-slate-700 dark:text-slate-200">Convert</h2>
         <div className="flex items-end gap-3">
           <div className="flex-1">
             <label className="label" htmlFor="color">Color (hex / rgb / hsl)</label>
@@ -45,7 +45,7 @@ export function Color() {
           </div>
           <div
             aria-hidden
-            className="h-10 w-16 rounded border border-slate-200"
+            className="h-10 w-16 rounded border border-slate-200 dark:border-slate-800"
             style={{ background: color }}
           />
         </div>
@@ -55,23 +55,23 @@ export function Color() {
       </form>
       <ErrorBanner message={conv.error} />
       {conv.data && conv.data.error && (
-        <div role="alert" className="rounded-md border border-rose-200 bg-rose-50 px-4 py-3 text-sm text-rose-900">
+        <div role="alert" className="rounded-md border border-rose-200 dark:border-rose-900 bg-rose-50 dark:bg-rose-950/40 px-4 py-3 text-sm text-rose-900 dark:text-rose-200">
           {conv.data.error}
         </div>
       )}
       {conv.data && !conv.data.error && (
         <section className="card text-sm">
           <dl className="grid grid-cols-[80px_1fr] gap-y-2">
-            <dt className="text-slate-500">HEX</dt><dd className="font-mono">{conv.data.hex}</dd>
-            <dt className="text-slate-500">RGB</dt><dd className="font-mono">{conv.data.rgb}</dd>
-            <dt className="text-slate-500">HSL</dt><dd className="font-mono">{conv.data.hsl}</dd>
-            <dt className="text-slate-500">OKLCH</dt><dd className="font-mono">{conv.data.oklch}</dd>
+            <dt className="text-slate-500 dark:text-slate-400">HEX</dt><dd className="font-mono">{conv.data.hex}</dd>
+            <dt className="text-slate-500 dark:text-slate-400">RGB</dt><dd className="font-mono">{conv.data.rgb}</dd>
+            <dt className="text-slate-500 dark:text-slate-400">HSL</dt><dd className="font-mono">{conv.data.hsl}</dd>
+            <dt className="text-slate-500 dark:text-slate-400">OKLCH</dt><dd className="font-mono">{conv.data.oklch}</dd>
           </dl>
         </section>
       )}
 
       <form onSubmit={onContrast} className="card space-y-4">
-        <h2 className="text-base font-semibold text-slate-700">Contrast (WCAG)</h2>
+        <h2 className="text-base font-semibold text-slate-700 dark:text-slate-200">Contrast (WCAG)</h2>
         <div className="grid gap-4 sm:grid-cols-2">
           <div>
             <label className="label" htmlFor="fg">Foreground</label>
@@ -82,7 +82,7 @@ export function Color() {
                 value={fg}
                 onChange={(e) => setFg(e.target.value)}
               />
-              <div aria-hidden className="h-9 w-9 rounded border border-slate-200" style={{ background: fg }} />
+              <div aria-hidden className="h-9 w-9 rounded border border-slate-200 dark:border-slate-800" style={{ background: fg }} />
             </div>
           </div>
           <div>
@@ -94,11 +94,11 @@ export function Color() {
                 value={bg}
                 onChange={(e) => setBg(e.target.value)}
               />
-              <div aria-hidden className="h-9 w-9 rounded border border-slate-200" style={{ background: bg }} />
+              <div aria-hidden className="h-9 w-9 rounded border border-slate-200 dark:border-slate-800" style={{ background: bg }} />
             </div>
           </div>
         </div>
-        <div className="rounded border border-slate-200 px-4 py-3" style={{ color: fg, background: bg }}>
+        <div className="rounded border border-slate-200 dark:border-slate-800 px-4 py-3" style={{ color: fg, background: bg }}>
           The quick brown fox jumps over the lazy dog.
         </div>
         <button type="submit" className="btn-secondary" disabled={contrast.pending}>
@@ -107,7 +107,7 @@ export function Color() {
       </form>
       <ErrorBanner message={contrast.error} />
       {contrast.data && contrast.data.error && (
-        <div role="alert" className="rounded-md border border-rose-200 bg-rose-50 px-4 py-3 text-sm text-rose-900">
+        <div role="alert" className="rounded-md border border-rose-200 dark:border-rose-900 bg-rose-50 dark:bg-rose-950/40 px-4 py-3 text-sm text-rose-900 dark:text-rose-200">
           {contrast.data.error}
         </div>
       )}
@@ -117,7 +117,7 @@ export function Color() {
             Ratio: <span className="font-mono text-base">{contrast.data.ratio}:1</span>
           </p>
           <table className="w-full">
-            <thead className="text-left text-slate-500">
+            <thead className="text-left text-slate-500 dark:text-slate-400">
               <tr>
                 <th className="py-1 font-medium">Level</th>
                 <th className="py-1 font-medium">Normal text</th>
@@ -125,21 +125,21 @@ export function Color() {
               </tr>
             </thead>
             <tbody>
-              <tr className="border-t border-slate-200">
+              <tr className="border-t border-slate-200 dark:border-slate-800">
                 <td className="py-1">AA (4.5 / 3.0)</td>
-                <td className={contrast.data.aa_normal ? "text-emerald-700" : "text-rose-700"}>
+                <td className={contrast.data.aa_normal ? "text-emerald-700 dark:text-emerald-300" : "text-rose-700 dark:text-rose-300"}>
                   {contrast.data.aa_normal ? "pass" : "fail"}
                 </td>
-                <td className={contrast.data.aa_large ? "text-emerald-700" : "text-rose-700"}>
+                <td className={contrast.data.aa_large ? "text-emerald-700 dark:text-emerald-300" : "text-rose-700 dark:text-rose-300"}>
                   {contrast.data.aa_large ? "pass" : "fail"}
                 </td>
               </tr>
-              <tr className="border-t border-slate-200">
+              <tr className="border-t border-slate-200 dark:border-slate-800">
                 <td className="py-1">AAA (7.0 / 4.5)</td>
-                <td className={contrast.data.aaa_normal ? "text-emerald-700" : "text-rose-700"}>
+                <td className={contrast.data.aaa_normal ? "text-emerald-700 dark:text-emerald-300" : "text-rose-700 dark:text-rose-300"}>
                   {contrast.data.aaa_normal ? "pass" : "fail"}
                 </td>
-                <td className={contrast.data.aaa_large ? "text-emerald-700" : "text-rose-700"}>
+                <td className={contrast.data.aaa_large ? "text-emerald-700 dark:text-emerald-300" : "text-rose-700 dark:text-rose-300"}>
                   {contrast.data.aaa_large ? "pass" : "fail"}
                 </td>
               </tr>

--- a/frontend/src/pages/calc/CronNext.tsx
+++ b/frontend/src/pages/calc/CronNext.tsx
@@ -64,13 +64,13 @@ export function CronNext() {
       </form>
       <ErrorBanner message={error} />
       {data && data.error && (
-        <div role="alert" className="rounded-md border border-rose-200 bg-rose-50 px-4 py-3 text-sm text-rose-900">
+        <div role="alert" className="rounded-md border border-rose-200 dark:border-rose-900 bg-rose-50 dark:bg-rose-950/40 px-4 py-3 text-sm text-rose-900 dark:text-rose-200">
           {data.error}
         </div>
       )}
       {data && !data.error && data.runs.length > 0 && (
         <section className="card">
-          <h3 className="mb-2 text-sm font-semibold text-slate-700">
+          <h3 className="mb-2 text-sm font-semibold text-slate-700 dark:text-slate-200">
             Next {data.runs.length} run{data.runs.length === 1 ? "" : "s"}
           </h3>
           <CodeBlock value={data.runs.join("\n")} />

--- a/frontend/src/pages/calc/MarkdownPreview.tsx
+++ b/frontend/src/pages/calc/MarkdownPreview.tsx
@@ -51,7 +51,7 @@ export function MarkdownPreview() {
         />
         <div className="card prose prose-sm max-w-none overflow-auto">
           {error && (
-            <div role="alert" className="rounded-md border border-rose-200 bg-rose-50 px-4 py-3 text-sm text-rose-900">
+            <div role="alert" className="rounded-md border border-rose-200 dark:border-rose-900 bg-rose-50 dark:bg-rose-950/40 px-4 py-3 text-sm text-rose-900 dark:text-rose-200">
               {error}
             </div>
           )}

--- a/frontend/src/pages/codec/CaseConverter.tsx
+++ b/frontend/src/pages/codec/CaseConverter.tsx
@@ -70,7 +70,7 @@ export function CaseConverter() {
       <ErrorBanner message={error} />
       {data && (
         <section className="card">
-          <h3 className="mb-2 text-sm font-semibold text-slate-700">Output</h3>
+          <h3 className="mb-2 text-sm font-semibold text-slate-700 dark:text-slate-200">Output</h3>
           <CodeBlock value={data.output} />
         </section>
       )}

--- a/frontend/src/pages/codec/HashTool.tsx
+++ b/frontend/src/pages/codec/HashTool.tsx
@@ -67,7 +67,7 @@ export function HashTool() {
       <ErrorBanner message={hash.error} />
       {hash.data && (
         <section className="card">
-          <h3 className="mb-2 text-sm font-semibold text-slate-700">Digests</h3>
+          <h3 className="mb-2 text-sm font-semibold text-slate-700 dark:text-slate-200">Digests</h3>
           <CodeBlock
             value={Object.entries(hash.data.digests)
               .map(([k, v]) => `${k}: ${v}`)
@@ -77,7 +77,7 @@ export function HashTool() {
       )}
 
       <form onSubmit={onHmac} className="card space-y-4">
-        <h2 className="text-base font-semibold text-slate-700">HMAC</h2>
+        <h2 className="text-base font-semibold text-slate-700 dark:text-slate-200">HMAC</h2>
         <div className="grid gap-4 sm:grid-cols-2">
           <div>
             <label className="label" htmlFor="secret">Secret</label>
@@ -110,7 +110,7 @@ export function HashTool() {
       <ErrorBanner message={hmac.error} />
       {hmac.data && (
         <section className="card">
-          <h3 className="mb-2 text-sm font-semibold text-slate-700">HMAC digest</h3>
+          <h3 className="mb-2 text-sm font-semibold text-slate-700 dark:text-slate-200">HMAC digest</h3>
           <CodeBlock value={hmac.data.digest} />
         </section>
       )}

--- a/frontend/src/pages/codec/JwtSigner.tsx
+++ b/frontend/src/pages/codec/JwtSigner.tsx
@@ -68,13 +68,13 @@ export function JwtSigner() {
       </form>
       <ErrorBanner message={error} />
       {data && data.error && (
-        <div role="alert" className="rounded-md border border-rose-200 bg-rose-50 px-4 py-3 text-sm text-rose-900">
+        <div role="alert" className="rounded-md border border-rose-200 dark:border-rose-900 bg-rose-50 dark:bg-rose-950/40 px-4 py-3 text-sm text-rose-900 dark:text-rose-200">
           {data.error}
         </div>
       )}
       {data && data.token && (
         <section className="card">
-          <h3 className="mb-2 text-sm font-semibold text-slate-700">Signed token</h3>
+          <h3 className="mb-2 text-sm font-semibold text-slate-700 dark:text-slate-200">Signed token</h3>
           <CodeBlock value={data.token} />
         </section>
       )}

--- a/frontend/src/pages/codec/UrlCodec.tsx
+++ b/frontend/src/pages/codec/UrlCodec.tsx
@@ -70,13 +70,13 @@ export function UrlCodec() {
       <ErrorBanner message={codec.error} />
       {codec.data && (
         <section className="card">
-          <h3 className="mb-2 text-sm font-semibold text-slate-700">Output</h3>
+          <h3 className="mb-2 text-sm font-semibold text-slate-700 dark:text-slate-200">Output</h3>
           <CodeBlock value={codec.data.output} />
         </section>
       )}
 
       <form onSubmit={onParse} className="card space-y-4">
-        <h2 className="text-base font-semibold text-slate-700">Query-string parser</h2>
+        <h2 className="text-base font-semibold text-slate-700 dark:text-slate-200">Query-string parser</h2>
         <div>
           <label className="label" htmlFor="qs">URL or query string</label>
           <input
@@ -95,27 +95,27 @@ export function UrlCodec() {
       {parse.data && (
         <section className="card">
           {parse.data.base && (
-            <p className="mb-2 text-xs text-slate-500">
-              Base: <span className="font-mono text-slate-700">{parse.data.base}</span>
+            <p className="mb-2 text-xs text-slate-500 dark:text-slate-400">
+              Base: <span className="font-mono text-slate-700 dark:text-slate-200">{parse.data.base}</span>
             </p>
           )}
           <table className="w-full text-sm">
             <thead>
-              <tr className="text-left text-slate-500">
+              <tr className="text-left text-slate-500 dark:text-slate-400">
                 <th className="py-1 pr-4 font-medium">Key</th>
                 <th className="py-1 font-medium">Value</th>
               </tr>
             </thead>
             <tbody>
               {parse.data.params.map((p, i) => (
-                <tr key={i} className="border-t border-slate-200">
+                <tr key={i} className="border-t border-slate-200 dark:border-slate-800">
                   <td className="py-1 pr-4 font-mono">{p.key}</td>
                   <td className="py-1 font-mono">{p.value}</td>
                 </tr>
               ))}
               {parse.data.params.length === 0 && (
                 <tr>
-                  <td colSpan={2} className="py-2 text-slate-500">No parameters.</td>
+                  <td colSpan={2} className="py-2 text-slate-500 dark:text-slate-400">No parameters.</td>
                 </tr>
               )}
             </tbody>

--- a/frontend/src/pages/codec/UuidGenerator.tsx
+++ b/frontend/src/pages/codec/UuidGenerator.tsx
@@ -43,7 +43,7 @@ export function UuidGenerator() {
       <PageHeader title="UUID" description="Generate and inspect UUIDs (v1, v3, v4, v5, v7)." />
 
       <form onSubmit={onGenerate} className="card space-y-4">
-        <h2 className="text-base font-semibold text-slate-700">Generate</h2>
+        <h2 className="text-base font-semibold text-slate-700 dark:text-slate-200">Generate</h2>
         <div className="flex flex-wrap items-end gap-4">
           <div>
             <label className="label" htmlFor="version">Version</label>
@@ -104,13 +104,13 @@ export function UuidGenerator() {
       <ErrorBanner message={gen.error} />
       {gen.data && (
         <section className="card">
-          <h3 className="mb-2 text-sm font-semibold text-slate-700">Generated</h3>
+          <h3 className="mb-2 text-sm font-semibold text-slate-700 dark:text-slate-200">Generated</h3>
           <CodeBlock value={gen.data.values.join("\n")} />
         </section>
       )}
 
       <form onSubmit={onInspect} className="card space-y-4">
-        <h2 className="text-base font-semibold text-slate-700">Inspect</h2>
+        <h2 className="text-base font-semibold text-slate-700 dark:text-slate-200">Inspect</h2>
         <div>
           <label className="label" htmlFor="inspect">UUID</label>
           <input
@@ -130,23 +130,23 @@ export function UuidGenerator() {
         <section className="card text-sm">
           {ins.data.valid ? (
             <dl className="grid grid-cols-[140px_1fr] gap-y-2">
-              <dt className="text-slate-500">Version</dt>
+              <dt className="text-slate-500 dark:text-slate-400">Version</dt>
               <dd>{ins.data.version}</dd>
-              <dt className="text-slate-500">Variant</dt>
+              <dt className="text-slate-500 dark:text-slate-400">Variant</dt>
               <dd>{ins.data.variant}</dd>
-              <dt className="text-slate-500">Hex</dt>
+              <dt className="text-slate-500 dark:text-slate-400">Hex</dt>
               <dd className="font-mono">{ins.data.hex}</dd>
-              <dt className="text-slate-500">URN</dt>
+              <dt className="text-slate-500 dark:text-slate-400">URN</dt>
               <dd className="font-mono">{ins.data.urn}</dd>
               {ins.data.timestamp_iso && (
                 <>
-                  <dt className="text-slate-500">Timestamp</dt>
+                  <dt className="text-slate-500 dark:text-slate-400">Timestamp</dt>
                   <dd className="font-mono">{ins.data.timestamp_iso}</dd>
                 </>
               )}
             </dl>
           ) : (
-            <p className="text-rose-700">Invalid UUID: {ins.data.error}</p>
+            <p className="text-rose-700 dark:text-rose-300">Invalid UUID: {ins.data.error}</p>
           )}
         </section>
       )}

--- a/frontend/src/pages/convert/CurlConverter.tsx
+++ b/frontend/src/pages/convert/CurlConverter.tsx
@@ -48,7 +48,7 @@ export function CurlConverter() {
       </form>
       <ErrorBanner message={error} />
       {data && data.error && (
-        <div role="alert" className="rounded-md border border-rose-200 bg-rose-50 px-4 py-3 text-sm text-rose-900">
+        <div role="alert" className="rounded-md border border-rose-200 dark:border-rose-900 bg-rose-50 dark:bg-rose-950/40 px-4 py-3 text-sm text-rose-900 dark:text-rose-200">
           {data.error}
         </div>
       )}
@@ -56,7 +56,7 @@ export function CurlConverter() {
         <div className="space-y-4">
           {langs.map(({ key, label }) => (
             <section key={key} className="card">
-              <h3 className="mb-2 text-sm font-semibold text-slate-700">{label}</h3>
+              <h3 className="mb-2 text-sm font-semibold text-slate-700 dark:text-slate-200">{label}</h3>
               <CodeBlock value={data.outputs[key] || ""} />
             </section>
           ))}

--- a/frontend/src/pages/convert/FormatConverter.tsx
+++ b/frontend/src/pages/convert/FormatConverter.tsx
@@ -75,13 +75,13 @@ export function FormatConverter() {
       </form>
       <ErrorBanner message={error} />
       {data && data.error && (
-        <div role="alert" className="rounded-md border border-rose-200 bg-rose-50 px-4 py-3 text-sm text-rose-900">
+        <div role="alert" className="rounded-md border border-rose-200 dark:border-rose-900 bg-rose-50 dark:bg-rose-950/40 px-4 py-3 text-sm text-rose-900 dark:text-rose-200">
           {data.error}
         </div>
       )}
       {data && !data.error && (
         <section className="card">
-          <h3 className="mb-2 text-sm font-semibold text-slate-700">Output</h3>
+          <h3 className="mb-2 text-sm font-semibold text-slate-700 dark:text-slate-200">Output</h3>
           <CodeBlock value={data.output} />
         </section>
       )}

--- a/frontend/src/pages/convert/JsonPath.tsx
+++ b/frontend/src/pages/convert/JsonPath.tsx
@@ -56,13 +56,13 @@ export function JsonPath() {
       </form>
       <ErrorBanner message={error} />
       {data && data.error && (
-        <div role="alert" className="rounded-md border border-rose-200 bg-rose-50 px-4 py-3 text-sm text-rose-900">
+        <div role="alert" className="rounded-md border border-rose-200 dark:border-rose-900 bg-rose-50 dark:bg-rose-950/40 px-4 py-3 text-sm text-rose-900 dark:text-rose-200">
           {data.error}
         </div>
       )}
       {data && !data.error && (
         <section className="card">
-          <h3 className="mb-2 text-sm font-semibold text-slate-700">
+          <h3 className="mb-2 text-sm font-semibold text-slate-700 dark:text-slate-200">
             Matches ({data.matches.length})
           </h3>
           <CodeBlock value={JSON.stringify(data.matches, null, 2)} />

--- a/frontend/src/pages/document/MarkdownPdf.tsx
+++ b/frontend/src/pages/document/MarkdownPdf.tsx
@@ -105,7 +105,7 @@ export function MarkdownPdf() {
 
       {extracted !== null && (
         <section className="card">
-          <h3 className="mb-2 text-sm font-semibold text-slate-700">Extracted text</h3>
+          <h3 className="mb-2 text-sm font-semibold text-slate-700 dark:text-slate-200">Extracted text</h3>
           <pre className="code whitespace-pre-wrap">{extracted}</pre>
         </section>
       )}

--- a/frontend/src/pages/encoding/Base64Page.tsx
+++ b/frontend/src/pages/encoding/Base64Page.tsx
@@ -67,7 +67,7 @@ export function Base64Page() {
 
       {data && (
         <section className="card">
-          <h3 className="mb-2 text-sm font-semibold text-slate-700">Output</h3>
+          <h3 className="mb-2 text-sm font-semibold text-slate-700 dark:text-slate-200">Output</h3>
           <CodeBlock value={data.output} />
         </section>
       )}

--- a/frontend/src/pages/encoding/JwtViewer.tsx
+++ b/frontend/src/pages/encoding/JwtViewer.tsx
@@ -57,10 +57,10 @@ export function JwtViewer() {
       {data && (
         <section className="card">
           {data.error ? (
-            <p className="rounded bg-rose-50 px-3 py-2 text-sm text-rose-900">{data.error}</p>
+            <p className="rounded bg-rose-50 dark:bg-rose-950/40 px-3 py-2 text-sm text-rose-900 dark:text-rose-200">{data.error}</p>
           ) : (
             <>
-              <h3 className="mb-2 text-sm font-semibold text-slate-700">Decoded JWT</h3>
+              <h3 className="mb-2 text-sm font-semibold text-slate-700 dark:text-slate-200">Decoded JWT</h3>
               <CodeBlock value={JSON.stringify(data.decoded, null, 2)} />
             </>
           )}

--- a/frontend/src/pages/fakeData/FakeData.tsx
+++ b/frontend/src/pages/fakeData/FakeData.tsx
@@ -110,7 +110,7 @@ export function FakeData() {
               </select>
               <button
                 type="button"
-                className="btn-ghost text-rose-600"
+                className="btn-ghost text-rose-600 dark:text-rose-400"
                 onClick={() => removeField(i)}
                 disabled={fields.length === 1}
               >
@@ -163,24 +163,24 @@ export function FakeData() {
 
       {preview && preview.length > 0 && (
         <section className="card overflow-x-auto p-0">
-          <table className="min-w-full divide-y divide-slate-200 text-xs">
-            <thead className="bg-slate-50">
+          <table className="min-w-full divide-y divide-slate-200 dark:divide-slate-800 text-xs">
+            <thead className="bg-slate-50 dark:bg-slate-800">
               <tr>
                 {Object.keys(preview[0]).map((k) => (
                   <th
                     key={k}
-                    className="px-3 py-2 text-left font-semibold uppercase tracking-wide text-slate-600"
+                    className="px-3 py-2 text-left font-semibold uppercase tracking-wide text-slate-600 dark:text-slate-300"
                   >
                     {k}
                   </th>
                 ))}
               </tr>
             </thead>
-            <tbody className="divide-y divide-slate-100">
+            <tbody className="divide-y divide-slate-100 dark:divide-slate-800">
               {preview.map((row, i) => (
-                <tr key={i} className="hover:bg-slate-50">
+                <tr key={i} className="hover:bg-slate-50 dark:hover:bg-slate-800">
                   {Object.keys(preview[0]).map((k) => (
-                    <td key={k} className="px-3 py-1 font-mono text-slate-800">
+                    <td key={k} className="px-3 py-1 font-mono text-slate-800 dark:text-slate-100">
                       {String(row[k] ?? "")}
                     </td>
                   ))}

--- a/frontend/src/pages/home/Home.tsx
+++ b/frontend/src/pages/home/Home.tsx
@@ -6,8 +6,8 @@ export function Home() {
   return (
     <div>
       <section className="mb-10 text-center">
-        <h1 className="text-4xl font-bold tracking-tight text-slate-900">Developer Tools</h1>
-        <p className="mt-3 text-base text-slate-600">
+        <h1 className="text-4xl font-bold tracking-tight text-slate-900 dark:text-slate-100">Developer Tools</h1>
+        <p className="mt-3 text-base text-slate-600 dark:text-slate-300">
           A small suite of practical tools for everyday development. Pick one below to get started.
         </p>
       </section>
@@ -15,19 +15,19 @@ export function Home() {
       <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
         {TOOL_GROUPS.map((group) => (
           <section key={group.label} className="card">
-            <h2 className="text-base font-semibold text-slate-900">{group.label}</h2>
+            <h2 className="text-base font-semibold text-slate-900 dark:text-slate-100">{group.label}</h2>
             <ul className="mt-3 space-y-2">
               {group.items.map((item) => (
                 <li key={item.path}>
                   <Link
                     to={item.path}
-                    className="group flex flex-col rounded p-2 hover:bg-slate-50"
+                    className="group flex flex-col rounded p-2 hover:bg-slate-50 dark:hover:bg-slate-800"
                   >
-                    <span className="text-sm font-medium text-slate-800 group-hover:text-brand">
+                    <span className="text-sm font-medium text-slate-800 dark:text-slate-100 group-hover:text-brand">
                       {item.label}
                     </span>
                     {item.description && (
-                      <span className="text-xs text-slate-500">{item.description}</span>
+                      <span className="text-xs text-slate-500 dark:text-slate-400">{item.description}</span>
                     )}
                   </Link>
                 </li>

--- a/frontend/src/pages/json/Converter.tsx
+++ b/frontend/src/pages/json/Converter.tsx
@@ -71,7 +71,7 @@ export function Converter() {
 
       {data && (
         <section className="card">
-          <h3 className="mb-2 text-sm font-semibold text-slate-700">Output</h3>
+          <h3 className="mb-2 text-sm font-semibold text-slate-700 dark:text-slate-200">Output</h3>
           <CodeBlock value={data.output} showLineNumbers />
         </section>
       )}

--- a/frontend/src/pages/json/Parser.tsx
+++ b/frontend/src/pages/json/Parser.tsx
@@ -43,7 +43,7 @@ export function Parser() {
 
       {data && (
         <section className="card">
-          <h3 className="mb-2 text-sm font-semibold text-slate-700">Parsed JSON</h3>
+          <h3 className="mb-2 text-sm font-semibold text-slate-700 dark:text-slate-200">Parsed JSON</h3>
           <CodeBlock value={data.output} showLineNumbers />
         </section>
       )}

--- a/frontend/src/pages/json/SampleGenerator.tsx
+++ b/frontend/src/pages/json/SampleGenerator.tsx
@@ -46,7 +46,7 @@ export function SampleGenerator() {
 
       {data && (
         <section className="card">
-          <h3 className="mb-2 text-sm font-semibold text-slate-700">Generated Sample JSON</h3>
+          <h3 className="mb-2 text-sm font-semibold text-slate-700 dark:text-slate-200">Generated Sample JSON</h3>
           <CodeBlock value={JSON.stringify(data.sample, null, 2)} showLineNumbers />
         </section>
       )}

--- a/frontend/src/pages/json/SchemaGenerator.tsx
+++ b/frontend/src/pages/json/SchemaGenerator.tsx
@@ -69,7 +69,7 @@ export function SchemaGenerator() {
 
       {data && (
         <section className="card">
-          <h3 className="mb-2 text-sm font-semibold text-slate-700">Generated JSON Schema</h3>
+          <h3 className="mb-2 text-sm font-semibold text-slate-700 dark:text-slate-200">Generated JSON Schema</h3>
           <CodeBlock value={JSON.stringify(data.schema, null, 2)} showLineNumbers />
         </section>
       )}

--- a/frontend/src/pages/json/Validator.tsx
+++ b/frontend/src/pages/json/Validator.tsx
@@ -64,16 +64,16 @@ export function Validator() {
           <p
             className={
               data.valid
-                ? "rounded bg-emerald-50 px-3 py-2 text-sm text-emerald-900"
-                : "rounded bg-rose-50 px-3 py-2 text-sm text-rose-900"
+                ? "rounded bg-emerald-50 dark:bg-emerald-950/40 px-3 py-2 text-sm text-emerald-900 dark:text-emerald-200"
+                : "rounded bg-rose-50 dark:bg-rose-950/40 px-3 py-2 text-sm text-rose-900 dark:text-rose-200"
             }
           >
             {data.message}
           </p>
-          {data.error_details && <p className="text-xs text-slate-600">{data.error_details}</p>}
+          {data.error_details && <p className="text-xs text-slate-600 dark:text-slate-300">{data.error_details}</p>}
           {data.formatted_json && (
             <div>
-              <h3 className="mb-1 text-sm font-semibold text-slate-700">Formatted JSON</h3>
+              <h3 className="mb-1 text-sm font-semibold text-slate-700 dark:text-slate-200">Formatted JSON</h3>
               <CodeBlock value={data.formatted_json} showLineNumbers />
             </div>
           )}

--- a/frontend/src/pages/misc/HttpStatuses.tsx
+++ b/frontend/src/pages/misc/HttpStatuses.tsx
@@ -6,11 +6,11 @@ import { ErrorBanner } from "../../components/ErrorBanner";
 import { PageHeader } from "../../components/PageHeader";
 
 function bandColor(code: number): string {
-  if (code < 200) return "bg-slate-100 text-slate-700";
-  if (code < 300) return "bg-emerald-100 text-emerald-800";
-  if (code < 400) return "bg-sky-100 text-sky-800";
-  if (code < 500) return "bg-amber-100 text-amber-800";
-  return "bg-rose-100 text-rose-800";
+  if (code < 200) return "bg-slate-100 dark:bg-slate-800 text-slate-700 dark:text-slate-200";
+  if (code < 300) return "bg-emerald-100 dark:bg-emerald-950/60 text-emerald-800 dark:text-emerald-200";
+  if (code < 400) return "bg-sky-100 dark:bg-sky-950/60 text-sky-800 dark:text-sky-200";
+  if (code < 500) return "bg-amber-100 dark:bg-amber-950/60 text-amber-800 dark:text-amber-200";
+  return "bg-rose-100 dark:bg-rose-950/60 text-rose-800 dark:text-rose-200";
 }
 
 export function HttpStatuses() {
@@ -52,12 +52,12 @@ export function HttpStatuses() {
             <li key={s.code} className="card flex items-start gap-4">
               <span className={`rounded px-2 py-1 text-sm font-mono ${bandColor(s.code)}`}>{s.code}</span>
               <div>
-                <p className="text-sm font-semibold text-slate-900">{s.name}</p>
-                <p className="text-sm text-slate-600">{s.description}</p>
+                <p className="text-sm font-semibold text-slate-900 dark:text-slate-100">{s.name}</p>
+                <p className="text-sm text-slate-600 dark:text-slate-300">{s.description}</p>
               </div>
             </li>
           ))}
-          {filtered.length === 0 && <p className="text-sm text-slate-500">No matches.</p>}
+          {filtered.length === 0 && <p className="text-sm text-slate-500 dark:text-slate-400">No matches.</p>}
         </ul>
       )}
     </div>

--- a/frontend/src/pages/misc/Lorem.tsx
+++ b/frontend/src/pages/misc/Lorem.tsx
@@ -67,7 +67,7 @@ export function Lorem() {
       <ErrorBanner message={error} />
       {data && (
         <section className="card">
-          <h3 className="mb-2 text-sm font-semibold text-slate-700">Output</h3>
+          <h3 className="mb-2 text-sm font-semibold text-slate-700 dark:text-slate-200">Output</h3>
           <CodeBlock value={data.text} />
         </section>
       )}

--- a/frontend/src/pages/misc/MimeTypes.tsx
+++ b/frontend/src/pages/misc/MimeTypes.tsx
@@ -41,7 +41,7 @@ export function MimeTypes() {
       {data && (
         <table className="w-full text-sm">
           <thead>
-            <tr className="text-left text-slate-500">
+            <tr className="text-left text-slate-500 dark:text-slate-400">
               <th className="py-1 pr-4 font-medium">Type</th>
               <th className="py-1 pr-4 font-medium">Extensions</th>
               <th className="py-1 font-medium">Description</th>
@@ -49,17 +49,17 @@ export function MimeTypes() {
           </thead>
           <tbody>
             {filtered.map((m) => (
-              <tr key={m.type} className="border-t border-slate-200">
+              <tr key={m.type} className="border-t border-slate-200 dark:border-slate-800">
                 <td className="py-1 pr-4 font-mono">{m.type}</td>
-                <td className="py-1 pr-4 font-mono text-slate-600">
+                <td className="py-1 pr-4 font-mono text-slate-600 dark:text-slate-300">
                   {m.extensions.map((e) => `.${e}`).join(", ") || "—"}
                 </td>
-                <td className="py-1 text-slate-700">{m.description}</td>
+                <td className="py-1 text-slate-700 dark:text-slate-200">{m.description}</td>
               </tr>
             ))}
             {filtered.length === 0 && (
               <tr>
-                <td colSpan={3} className="py-2 text-slate-500">No matches.</td>
+                <td colSpan={3} className="py-2 text-slate-500 dark:text-slate-400">No matches.</td>
               </tr>
             )}
           </tbody>

--- a/frontend/src/pages/misc/QrCode.tsx
+++ b/frontend/src/pages/misc/QrCode.tsx
@@ -83,13 +83,13 @@ export function QrCode() {
       </form>
       <ErrorBanner message={error} />
       {data && data.error && (
-        <div role="alert" className="rounded-md border border-rose-200 bg-rose-50 px-4 py-3 text-sm text-rose-900">
+        <div role="alert" className="rounded-md border border-rose-200 dark:border-rose-900 bg-rose-50 dark:bg-rose-950/40 px-4 py-3 text-sm text-rose-900 dark:text-rose-200">
           {data.error}
         </div>
       )}
       {data && data.svg && (
         <section className="card flex flex-col items-center gap-4">
-          <div className="bg-white p-4" dangerouslySetInnerHTML={{ __html: data.svg }} />
+          <div className="bg-white dark:bg-slate-900 p-4" dangerouslySetInnerHTML={{ __html: data.svg }} />
           <button type="button" onClick={downloadSvg} className="btn-secondary">
             Download SVG
           </button>

--- a/frontend/src/pages/regex/Checker.tsx
+++ b/frontend/src/pages/regex/Checker.tsx
@@ -59,10 +59,10 @@ export function RegexChecker() {
           <p
             className={
               data.match === true
-                ? "rounded bg-emerald-50 px-3 py-2 text-sm text-emerald-900"
+                ? "rounded bg-emerald-50 dark:bg-emerald-950/40 px-3 py-2 text-sm text-emerald-900 dark:text-emerald-200"
                 : data.match === false
-                  ? "rounded bg-amber-50 px-3 py-2 text-sm text-amber-900"
-                  : "rounded bg-rose-50 px-3 py-2 text-sm text-rose-900"
+                  ? "rounded bg-amber-50 dark:bg-amber-950/40 px-3 py-2 text-sm text-amber-900 dark:text-amber-200"
+                  : "rounded bg-rose-50 dark:bg-rose-950/40 px-3 py-2 text-sm text-rose-900 dark:text-rose-200"
             }
           >
             {data.message}

--- a/frontend/src/pages/regex/Generator.tsx
+++ b/frontend/src/pages/regex/Generator.tsx
@@ -46,7 +46,7 @@ export function RegexGenerator() {
 
       {data && (
         <section className="card">
-          <h3 className="mb-2 text-sm font-semibold text-slate-700">Pattern</h3>
+          <h3 className="mb-2 text-sm font-semibold text-slate-700 dark:text-slate-200">Pattern</h3>
           <CodeBlock value={data.pattern} />
         </section>
       )}

--- a/frontend/src/pages/string/CleanText.tsx
+++ b/frontend/src/pages/string/CleanText.tsx
@@ -46,7 +46,7 @@ export function CleanText() {
 
       {data && (
         <section className="card">
-          <h3 className="mb-2 text-sm font-semibold text-slate-700">Cleaned Text</h3>
+          <h3 className="mb-2 text-sm font-semibold text-slate-700 dark:text-slate-200">Cleaned Text</h3>
           <CodeBlock value={data.cleaned} />
         </section>
       )}

--- a/frontend/src/pages/string/ColumnExtractor.tsx
+++ b/frontend/src/pages/string/ColumnExtractor.tsx
@@ -74,7 +74,7 @@ export function ColumnExtractor() {
 
       {data && (
         <section className="card">
-          <h3 className="mb-2 text-sm font-semibold text-slate-700">Extracted Columns</h3>
+          <h3 className="mb-2 text-sm font-semibold text-slate-700 dark:text-slate-200">Extracted Columns</h3>
           <CodeBlock value={data.columns.join("\n")} />
         </section>
       )}

--- a/frontend/src/pages/string/DiffViewer.tsx
+++ b/frontend/src/pages/string/DiffViewer.tsx
@@ -8,10 +8,10 @@ import { PageHeader } from "../../components/PageHeader";
 import { useApi } from "../../hooks/useApi";
 
 const TAG_STYLE: Record<string, string> = {
-  equal: "bg-white",
-  insert: "bg-emerald-50",
-  delete: "bg-rose-50",
-  replace: "bg-amber-50",
+  equal: "bg-white dark:bg-slate-900",
+  insert: "bg-emerald-50 dark:bg-emerald-950/40",
+  delete: "bg-rose-50 dark:bg-rose-950/40",
+  replace: "bg-amber-50 dark:bg-amber-950/40",
 };
 
 function renderSide(hunks: DiffHunk[], side: "left" | "right") {
@@ -91,11 +91,11 @@ export function DiffViewer() {
 
       {data && (
         <section className="card overflow-hidden p-0">
-          <div className="grid grid-cols-2 divide-x divide-slate-200 font-mono text-xs">
-            <div className="bg-slate-50 px-3 py-2 text-[11px] font-semibold uppercase text-slate-500">
+          <div className="grid grid-cols-2 divide-x divide-slate-200 dark:divide-slate-800 font-mono text-xs">
+            <div className="bg-slate-50 dark:bg-slate-800 px-3 py-2 text-[11px] font-semibold uppercase text-slate-500 dark:text-slate-400">
               Text 1
             </div>
-            <div className="bg-slate-50 px-3 py-2 text-[11px] font-semibold uppercase text-slate-500">
+            <div className="bg-slate-50 dark:bg-slate-800 px-3 py-2 text-[11px] font-semibold uppercase text-slate-500 dark:text-slate-400">
               Text 2
             </div>
             {Array.from({ length: rowCount }).map((_, i) => {
@@ -121,13 +121,13 @@ function Row({ l, r }: { l: Row; r: Row }) {
   return (
     <>
       <div className={clsx("flex gap-3 px-3 py-1", TAG_STYLE[l.tag])}>
-        <span className="w-8 select-none text-right text-slate-400">
+        <span className="w-8 select-none text-right text-slate-400 dark:text-slate-500">
           {l.lineNumber > 0 ? l.lineNumber : ""}
         </span>
         <span className="whitespace-pre-wrap break-all">{l.text}</span>
       </div>
       <div className={clsx("flex gap-3 px-3 py-1", TAG_STYLE[r.tag])}>
-        <span className="w-8 select-none text-right text-slate-400">
+        <span className="w-8 select-none text-right text-slate-400 dark:text-slate-500">
           {r.lineNumber > 0 ? r.lineNumber : ""}
         </span>
         <span className="whitespace-pre-wrap break-all">{r.text}</span>

--- a/frontend/src/pages/string/RandomNumber.tsx
+++ b/frontend/src/pages/string/RandomNumber.tsx
@@ -58,7 +58,7 @@ export function RandomNumber() {
 
       {data && (
         <section className="card">
-          <p className="text-xs uppercase tracking-wide text-slate-500">Your Random Number</p>
+          <p className="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">Your Random Number</p>
           <p className="font-mono text-2xl font-semibold">{data.value}</p>
         </section>
       )}

--- a/frontend/src/pages/string/RandomString.tsx
+++ b/frontend/src/pages/string/RandomString.tsx
@@ -45,7 +45,7 @@ export function RandomString() {
 
       {data && (
         <section className="card">
-          <h3 className="mb-2 text-sm font-semibold text-slate-700">Your Random String</h3>
+          <h3 className="mb-2 text-sm font-semibold text-slate-700 dark:text-slate-200">Your Random String</h3>
           <CodeBlock value={data.value} />
         </section>
       )}

--- a/frontend/src/pages/string/ShuffleLetters.tsx
+++ b/frontend/src/pages/string/ShuffleLetters.tsx
@@ -42,7 +42,7 @@ export function ShuffleLetters() {
 
       {data && (
         <section className="card">
-          <h3 className="mb-2 text-sm font-semibold text-slate-700">Shuffled Text</h3>
+          <h3 className="mb-2 text-sm font-semibold text-slate-700 dark:text-slate-200">Shuffled Text</h3>
           <CodeBlock value={data.value} />
         </section>
       )}

--- a/frontend/src/pages/string/TextStatistics.tsx
+++ b/frontend/src/pages/string/TextStatistics.tsx
@@ -54,12 +54,12 @@ export function TextStatistics() {
 
       {data && (
         <section className="card">
-          <h3 className="mb-3 text-sm font-semibold text-slate-700">Text Statistics</h3>
+          <h3 className="mb-3 text-sm font-semibold text-slate-700 dark:text-slate-200">Text Statistics</h3>
           <dl className="grid gap-3 sm:grid-cols-2">
             {ROWS.map((row) => (
-              <div key={row.key} className="rounded border border-slate-200 p-3">
-                <dt className="text-xs uppercase tracking-wide text-slate-500">{row.label}</dt>
-                <dd className="text-base font-semibold text-slate-900">
+              <div key={row.key} className="rounded border border-slate-200 dark:border-slate-800 p-3">
+                <dt className="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">{row.label}</dt>
+                <dd className="text-base font-semibold text-slate-900 dark:text-slate-100">
                   {row.format ? row.format(data[row.key] as number) : data[row.key]}
                 </dd>
               </div>

--- a/frontend/src/pages/time/CronScheduler.tsx
+++ b/frontend/src/pages/time/CronScheduler.tsx
@@ -49,7 +49,7 @@ export function CronScheduler() {
           {FIELDS.map((f) => (
             <div key={f.key}>
               <label className="label" htmlFor={f.key}>
-                {f.label} <span className="text-xs text-slate-500">({f.help})</span>
+                {f.label} <span className="text-xs text-slate-500 dark:text-slate-400">({f.help})</span>
               </label>
               <input
                 id={f.key}
@@ -69,7 +69,7 @@ export function CronScheduler() {
 
       {data && (
         <section className="card">
-          <h3 className="mb-2 text-sm font-semibold text-slate-700">CRON Expression</h3>
+          <h3 className="mb-2 text-sm font-semibold text-slate-700 dark:text-slate-200">CRON Expression</h3>
           <CodeBlock value={data.expression} />
         </section>
       )}

--- a/frontend/src/pages/time/TimeConverter.tsx
+++ b/frontend/src/pages/time/TimeConverter.tsx
@@ -48,10 +48,10 @@ export function TimeConverter() {
           <dl className="space-y-3">
             {Object.entries(data.output).map(([k, v]) => (
               <div key={k} className="flex flex-col gap-1 sm:flex-row sm:items-baseline sm:gap-3">
-                <dt className="w-56 shrink-0 text-xs uppercase tracking-wide text-slate-500">
+                <dt className="w-56 shrink-0 text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">
                   {k}
                 </dt>
-                <dd className="font-mono text-sm text-slate-800">
+                <dd className="font-mono text-sm text-slate-800 dark:text-slate-100">
                   {Array.isArray(v) ? (
                     <ul className="space-y-1">
                       {v.map((line) => (

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -6,6 +6,9 @@
   :root {
     color-scheme: light;
   }
+  .dark {
+    color-scheme: dark;
+  }
   body {
     font-family: theme("fontFamily.sans");
   }
@@ -13,27 +16,27 @@
 
 @layer components {
   .btn {
-    @apply inline-flex items-center justify-center rounded-md px-4 py-2 text-sm font-medium transition focus:outline-none focus-visible:ring-2 focus-visible:ring-brand focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-60;
+    @apply inline-flex items-center justify-center rounded-md px-4 py-2 text-sm font-medium transition focus:outline-none focus-visible:ring-2 focus-visible:ring-brand focus-visible:ring-offset-2 dark:focus-visible:ring-offset-slate-900 disabled:cursor-not-allowed disabled:opacity-60;
   }
   .btn-primary {
     @apply btn bg-brand text-white hover:bg-brand-600;
   }
   .btn-secondary {
-    @apply btn border border-slate-300 bg-white text-slate-700 hover:bg-slate-50;
+    @apply btn border border-slate-300 bg-white text-slate-700 hover:bg-slate-50 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-200 dark:hover:bg-slate-700;
   }
   .btn-ghost {
-    @apply btn text-slate-600 hover:bg-slate-100;
+    @apply btn text-slate-600 hover:bg-slate-100 dark:text-slate-300 dark:hover:bg-slate-800;
   }
   .input {
-    @apply block w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm shadow-sm focus:border-brand focus:outline-none focus:ring-1 focus:ring-brand;
+    @apply block w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm shadow-sm focus:border-brand focus:outline-none focus:ring-1 focus:ring-brand dark:border-slate-700 dark:bg-slate-950 dark:text-slate-100 dark:placeholder-slate-500;
   }
   .label {
-    @apply mb-1 block text-sm font-medium text-slate-700;
+    @apply mb-1 block text-sm font-medium text-slate-700 dark:text-slate-300;
   }
   .card {
-    @apply rounded-lg border border-slate-200 bg-white p-6 shadow-sm;
+    @apply rounded-lg border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-800 dark:bg-slate-900;
   }
   .code {
-    @apply whitespace-pre-wrap break-words rounded-md border border-slate-200 bg-slate-50 p-4 font-mono text-xs text-slate-800;
+    @apply whitespace-pre-wrap break-words rounded-md border border-slate-200 bg-slate-50 p-4 font-mono text-xs text-slate-800 dark:border-slate-800 dark:bg-slate-950 dark:text-slate-200;
   }
 }

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,5 +1,6 @@
 /** @type {import('tailwindcss').Config} */
 export default {
+  darkMode: "class",
   content: ["./index.html", "./src/**/*.{ts,tsx}"],
   theme: {
     extend: {


### PR DESCRIPTION
## What

Adds a full dark/light theme across the whole app, with **dark as the default**.

- **`tailwind.config.js`** — enables `darkMode: 'class'`.
- **`index.html`** — an inline `<script>` in `<head>` applies the saved theme to `<html>` **before first paint**, so there's no flash. Dark is the default; only an explicit `light` choice in `localStorage` opts out. Adds `<meta name="color-scheme" content="dark light">`.
- **`ThemeToggle.tsx`** (new) — a sun/moon button in the navbar that flips the theme and persists the choice to `localStorage`.
- **`styles.css`** — the shared component classes (`card`, `input`, `label`, `btn-secondary`, `btn-ghost`, `code`) now carry `dark:` variants, so all form chrome themes automatically.
- **Component + page sweep** — `Navbar`, `Layout`, `PageHeader`, `CodeBlock`, `ErrorBanner` and all 38 tool pages had `dark:` variants added to their inline color utilities (202 `dark:` classes total).

## Approach

Light-mode color utilities were kept and matched 1:1 with `dark:` counterparts (e.g. `text-slate-700` → `text-slate-700 dark:text-slate-200`, `bg-rose-50` → `… dark:bg-rose-950/40`). No logic, structure, or non-color styling changed. Brand colors are theme-agnostic and untouched.

## Verification

- `npm run build` (`tsc -b && vite build`) passes clean; CSS compiles to 22.9 kB with all `dark:` variants.
- Grep confirms every line carrying a base color utility also carries a `dark:` variant.
- Manual check recommended: toggle the theme, reload (persistence + no-flash), and click through a few tool pages.

## Note (out of scope)

`MarkdownPreview.tsx` uses `prose prose-sm`, but `@tailwindcss/typography` isn't installed, so those classes are already no-ops. Rendered markdown text inherits the body color and stays readable in both themes. Not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)