### PR TITLE
Add favicon and social/SEO meta tags

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -6,6 +6,19 @@
     <meta name="color-scheme" content="dark light" />
     <title>Developer Tools</title>
     <meta name="description" content="A suite of developer tools: JSON, regex, strings, encoding, time, and more." />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <meta name="theme-color" content="#0f172a" />
+
+    <!-- Open Graph / social link previews -->
+    <meta property="og:type" content="website" />
+    <meta property="og:site_name" content="Developer Tools" />
+    <meta property="og:title" content="Developer Tools" />
+    <meta property="og:description" content="A suite of developer tools: JSON, regex, strings, encoding, time, and more." />
+    <meta property="og:url" content="https://wrench.tools/" />
+
+    <meta name="twitter:card" content="summary" />
+    <meta name="twitter:title" content="Developer Tools" />
+    <meta name="twitter:description" content="A suite of developer tools: JSON, regex, strings, encoding, time, and more." />
     <script>
       // Apply the saved theme before first paint to avoid a flash of the wrong
       // colors. Dark is the default — only an explicit "light" choice opts out.

--- a/frontend/public/favicon.svg
+++ b/frontend/public/favicon.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 64 64">
+  <rect width="64" height="64" rx="14" fill="#6225e6" />
+  <text x="32" y="33" text-anchor="middle" dominant-baseline="central"
+        font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif"
+        font-size="30" font-weight="700" fill="#ffffff">DT</text>
+</svg>


### PR DESCRIPTION
## What

Polish for the new `wrench.tools` domain — purely additive, no renames, no logic changes.

- **`frontend/public/favicon.svg`** (new) — an SVG favicon: a brand-purple rounded badge with the "DT" mark, mirroring the in-app navbar logo. The site had no favicon at all (no `public/` dir existed). Vite copies it to `dist/`, and the backend's SPA catchall serves it at `/favicon.svg`.
- **`index.html`** — adds Open Graph + Twitter Card tags so links shared on Slack / iMessage / etc. render a proper preview, plus a `theme-color` matching the dark default.

## Why no code changes were needed

The app already works at any origin: `api/client.ts` uses relative `fetch("/api/...")` paths, the SPA is served same-origin with the API (so CORS never triggers in production), and no host is hardcoded anywhere. Kept "Developer Tools" branding per the product decision.

## Verification

- `npm run build` passes; `index.html` 1.2 kB → 2.0 kB, `dist/favicon.svg` emitted.

## Optional follow-ups (not done here)

- A 1200×630 `og-image.png` would upgrade link previews from a small card to a large image card (`twitter:card` → `summary_large_image`).
- An `apple-touch-icon.png` for iOS home-screen pinning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added favicon and theme color customization for improved browser appearance
  * Enabled rich social media previews when sharing links across platforms

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vib795/everyday-developer-tools/pull/52?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->