### PR TITLE
Render diff viewer side-by-side like a GitHub PR review

### DIFF
--- a/frontend/src/pages/string/DiffViewer.tsx
+++ b/frontend/src/pages/string/DiffViewer.tsx
@@ -7,28 +7,170 @@ import { ErrorBanner } from "../../components/ErrorBanner";
 import { PageHeader } from "../../components/PageHeader";
 import { useApi } from "../../hooks/useApi";
 
-const TAG_STYLE: Record<string, string> = {
+type CellKind = "equal" | "add" | "del" | "empty";
+
+/** A run of text within a line, flagged if it differs from the paired line. */
+interface Segment {
+  text: string;
+  changed: boolean;
+}
+
+/** One half of a rendered row. "empty" means this side has no counterpart line. */
+interface Cell {
+  lineNumber: number;
+  segments: Segment[];
+  kind: CellKind;
+}
+
+interface RowPair {
+  left: Cell;
+  right: Cell;
+}
+
+const ROW_BG: Record<CellKind, string> = {
   equal: "bg-white dark:bg-slate-900",
-  insert: "bg-emerald-50 dark:bg-emerald-950/40",
-  delete: "bg-rose-50 dark:bg-rose-950/40",
-  replace: "bg-amber-50 dark:bg-amber-950/40",
+  add: "bg-emerald-50 dark:bg-emerald-950/40",
+  del: "bg-rose-50 dark:bg-rose-950/40",
+  empty: "bg-slate-50 dark:bg-slate-900/60",
 };
 
-function renderSide(hunks: DiffHunk[], side: "left" | "right") {
-  const rows: { lineNumber: number; text: string; tag: string }[] = [];
+/** Deeper shade marking the words that actually changed inside a replaced line. */
+const WORD_BG: Record<CellKind, string> = {
+  equal: "",
+  add: "bg-emerald-200 dark:bg-emerald-700/50",
+  del: "bg-rose-200 dark:bg-rose-700/50",
+  empty: "",
+};
+
+const MARKER: Record<CellKind, string> = {
+  equal: "",
+  add: "+",
+  del: "-",
+  empty: "",
+};
+
+const MARKER_COLOR: Record<CellKind, string> = {
+  equal: "",
+  add: "text-emerald-600 dark:text-emerald-400",
+  del: "text-rose-600 dark:text-rose-400",
+  empty: "",
+};
+
+const EMPTY_CELL: Cell = { lineNumber: -1, segments: [], kind: "empty" };
+
+// Words, whitespace runs, and single punctuation marks. Joining the matches back
+// together reproduces the line exactly, so segments never lose characters.
+const TOKEN_RE = /[A-Za-z0-9_]+|\s+|[^A-Za-z0-9_\s]/g;
+
+// Past this many tokens the O(n*m) LCS table costs more than the highlight is
+// worth; such a pair still renders as a full-line change, just without the
+// word-level shading.
+const WORD_DIFF_LIMIT = 400;
+
+function segment(text: string, changed: boolean): Segment[] {
+  return text === "" ? [] : [{ text, changed }];
+}
+
+/** Append to `out`, merging into the previous run when the flag matches. */
+function push(out: Segment[], text: string, changed: boolean) {
+  const last = out[out.length - 1];
+  if (last && last.changed === changed) last.text += text;
+  else out.push({ text, changed });
+}
+
+/**
+ * Split a replaced line pair into segments, flagging the tokens outside their
+ * longest common subsequence — the intra-line highlight GitHub shows on a
+ * side-by-side review.
+ */
+function wordDiff(oldLine: string, newLine: string): [Segment[], Segment[]] {
+  const a = oldLine.match(TOKEN_RE) ?? [];
+  const b = newLine.match(TOKEN_RE) ?? [];
+  if (a.length > WORD_DIFF_LIMIT || b.length > WORD_DIFF_LIMIT) {
+    return [segment(oldLine, true), segment(newLine, true)];
+  }
+
+  // lcs[i][j] = length of the longest common subsequence of a[i:] and b[j:].
+  const lcs: number[][] = Array.from({ length: a.length + 1 }, () =>
+    new Array<number>(b.length + 1).fill(0),
+  );
+  for (let i = a.length - 1; i >= 0; i--) {
+    for (let j = b.length - 1; j >= 0; j--) {
+      lcs[i][j] =
+        a[i] === b[j] ? lcs[i + 1][j + 1] + 1 : Math.max(lcs[i + 1][j], lcs[i][j + 1]);
+    }
+  }
+
+  const left: Segment[] = [];
+  const right: Segment[] = [];
+  let i = 0;
+  let j = 0;
+  while (i < a.length && j < b.length) {
+    if (a[i] === b[j]) {
+      push(left, a[i], false);
+      push(right, b[j], false);
+      i++;
+      j++;
+    } else if (lcs[i + 1][j] >= lcs[i][j + 1]) {
+      push(left, a[i], true);
+      i++;
+    } else {
+      push(right, b[j], true);
+      j++;
+    }
+  }
+  while (i < a.length) push(left, a[i++], true);
+  while (j < b.length) push(right, b[j++], true);
+  return [left, right];
+}
+
+/**
+ * Flatten hunks into aligned row pairs. Every hunk contributes the same number
+ * of rows to both columns — the short side gets blank filler — so the two
+ * columns stay in step for the whole document.
+ */
+function buildRows(hunks: DiffHunk[]): RowPair[] {
+  const rows: RowPair[] = [];
   for (const h of hunks) {
-    const lines = side === "left" ? h.left : h.right;
-    const start = side === "left" ? h.left_start : h.right_start;
-    const isPad =
-      (side === "left" && h.tag === "insert") || (side === "right" && h.tag === "delete");
-    if (lines.length === 0 && (h.tag === "insert" || h.tag === "delete")) {
-      const otherLen = (side === "left" ? h.right : h.left).length;
-      for (let i = 0; i < otherLen; i++) rows.push({ lineNumber: -1, text: "", tag: h.tag });
+    if (h.tag === "equal") {
+      h.left.forEach((text, i) => {
+        rows.push({
+          left: { lineNumber: h.left_start + i + 1, segments: segment(text, false), kind: "equal" },
+          right: {
+            lineNumber: h.right_start + i + 1,
+            segments: segment(h.right[i], false),
+            kind: "equal",
+          },
+        });
+      });
       continue;
     }
-    lines.forEach((text, i) =>
-      rows.push({ lineNumber: isPad ? -1 : start + i + 1, text, tag: h.tag }),
-    );
+
+    for (let i = 0; i < Math.max(h.left.length, h.right.length); i++) {
+      const oldText: string | undefined = h.left[i];
+      const newText: string | undefined = h.right[i];
+      if (oldText !== undefined && newText !== undefined) {
+        const [leftSegments, rightSegments] = wordDiff(oldText, newText);
+        rows.push({
+          left: { lineNumber: h.left_start + i + 1, segments: leftSegments, kind: "del" },
+          right: { lineNumber: h.right_start + i + 1, segments: rightSegments, kind: "add" },
+        });
+      } else if (oldText !== undefined) {
+        rows.push({
+          left: { lineNumber: h.left_start + i + 1, segments: segment(oldText, false), kind: "del" },
+          right: EMPTY_CELL,
+        });
+      } else if (newText !== undefined) {
+        rows.push({
+          left: EMPTY_CELL,
+          right: {
+            lineNumber: h.right_start + i + 1,
+            segments: segment(newText, false),
+            kind: "add",
+          },
+        });
+      }
+    }
   }
   return rows;
 }
@@ -45,16 +187,11 @@ export function DiffViewer() {
     run({ text1, text2 });
   }
 
-  const left = data ? renderSide(data.hunks, "left") : [];
-  const right = data ? renderSide(data.hunks, "right") : [];
-  const rowCount = Math.max(left.length, right.length);
+  const rows = data ? buildRows(data.hunks) : [];
 
   return (
     <div className="space-y-6">
-      <PageHeader
-        title="Diff Viewer"
-        description="Compare two pieces of text side-by-side."
-      />
+      <PageHeader title="Diff Viewer" description="Compare two pieces of text side-by-side." />
       <form onSubmit={onSubmit} className="card space-y-4">
         <div className="grid gap-4 md:grid-cols-2">
           <div>
@@ -98,13 +235,9 @@ export function DiffViewer() {
             <div className="bg-slate-50 dark:bg-slate-800 px-3 py-2 text-[11px] font-semibold uppercase text-slate-500 dark:text-slate-400">
               Text 2
             </div>
-            {Array.from({ length: rowCount }).map((_, i) => {
-              const l = left[i] ?? { lineNumber: -1, text: "", tag: "equal" };
-              const r = right[i] ?? { lineNumber: -1, text: "", tag: "equal" };
-              return (
-                <Row key={`row-${i}`} l={l} r={r} />
-              );
-            })}
+            {rows.map((row, i) => (
+              <Row key={`row-${i}`} row={row} />
+            ))}
           </div>
         </section>
       )}
@@ -112,26 +245,40 @@ export function DiffViewer() {
   );
 }
 
-interface Row {
-  lineNumber: number;
-  text: string;
-  tag: string;
-}
-function Row({ l, r }: { l: Row; r: Row }) {
+function Row({ row }: { row: RowPair }) {
   return (
     <>
-      <div className={clsx("flex gap-3 px-3 py-1", TAG_STYLE[l.tag])}>
-        <span className="w-8 select-none text-right text-slate-400 dark:text-slate-500">
-          {l.lineNumber > 0 ? l.lineNumber : ""}
-        </span>
-        <span className="whitespace-pre-wrap break-all">{l.text}</span>
-      </div>
-      <div className={clsx("flex gap-3 px-3 py-1", TAG_STYLE[r.tag])}>
-        <span className="w-8 select-none text-right text-slate-400 dark:text-slate-500">
-          {r.lineNumber > 0 ? r.lineNumber : ""}
-        </span>
-        <span className="whitespace-pre-wrap break-all">{r.text}</span>
-      </div>
+      <Side cell={row.left} />
+      <Side cell={row.right} />
     </>
+  );
+}
+
+function Side({ cell }: { cell: Cell }) {
+  return (
+    <div className={clsx("flex gap-2 px-3 py-1", ROW_BG[cell.kind])}>
+      <span className="w-8 shrink-0 select-none text-right text-slate-400 dark:text-slate-500">
+        {cell.lineNumber > 0 ? cell.lineNumber : ""}
+      </span>
+      <span
+        className={clsx(
+          "w-3 shrink-0 select-none text-center font-semibold",
+          MARKER_COLOR[cell.kind],
+        )}
+      >
+        {MARKER[cell.kind]}
+      </span>
+      <span className="whitespace-pre-wrap break-all">
+        {cell.segments.map((s, i) =>
+          s.changed ? (
+            <mark key={i} className={clsx("rounded-sm text-inherit", WORD_BG[cell.kind])}>
+              {s.text}
+            </mark>
+          ) : (
+            <span key={i}>{s.text}</span>
+          ),
+        )}
+      </span>
+    </div>
   );
 }


### PR DESCRIPTION
## Problem

Three defects in `frontend/src/pages/string/DiffViewer.tsx`, reported from the live tool:

1. **No `+`/`-` markers.** `Row` rendered only a line number and text.
2. **A `replace` hunk painted both sides one color** (`bg-amber-50 dark:bg-amber-950/40`), which reads as red in dark mode — so a changed pair looked "all red" on both sides instead of red-old / green-new.
3. **Row misalignment (real bug).** `renderSide` built each column independently and the component zipped them by array index. Confirmed against the backend: a `replace` hunk of 2 old → 4 new lines gave the left column 5 rows and the right 7, so every row after it paired unrelated lines. The extra new lines never rendered as additions — they silently shifted the alignment.

## Fix

`buildRows` emits **aligned pairs**; each hunk contributes equal row counts to both columns, padding the short side with blank filler.

| | Left | Right |
|---|---|---|
| replace, paired | `-` rose, changed words deeper rose | `+` emerald, changed words deeper emerald |
| extra new line | blank filler | `+` emerald |
| extra old line | `-` rose | blank filler |
| equal | neutral | neutral |

Word-level highlighting comes from a token LCS, so shared prefix/suffix stay unshaded — matching GitHub's intra-line highlight.

Rendering only. The backend's `structured_diff` already returned everything needed, so `services/`, `schemas/`, `routers/`, and `api/types.ts` are untouched.

## Verification

- `npm run lint` (tsc --noEmit) clean
- Live in dev: 2→4 replace produced `old-a↔new-a`, `old-b↔new-b`, then `new-c`/`new-d` as `+` against filler, then `keep2↔keep2` (L4/R6) and `keep3↔keep3` (L5/R7) correctly re-aligned
- Word diff on a long LaTeX line left the shared prefix/suffix unmarked
- No console errors; dark and light mode both checked

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added aligned side-by-side comparison rows for clearer diff viewing.
  - Added word-level highlighting for replaced lines.
  - Added visual markers and backgrounds for unchanged, added, deleted, and empty lines.
  - Preserved alignment when compared sections contain different numbers of lines.
  - Continued displaying line numbers and highlighted change segments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->