### PR TITLE
Ignore gstack skill state directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -173,3 +173,5 @@ frontend/.vite/
 # Logs
 logs/
 
+# gstack skill state
+.gstack/


### PR DESCRIPTION
The gstack browse skill writes session and analytics state to `.gstack/` in the working tree, which showed up as untracked noise in `git status`.

One line, grouped under a section comment to match the rest of the file. No runtime impact — nothing imports `.gitignore`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)